### PR TITLE
tweak layout on about page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -3,13 +3,13 @@ import Link from "next/link";
 
 export default function About() {
   return (
-    <div className="max-w-[512px] mx-auto my-10 p-10 bg-white rounded-lg">
+    <div className="max-w-[512px] mx-auto p-10 bg-white rounded-lg">
       <Head>
         <title>Inpainting with Stable Diffusion &amp; Replicate</title>
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       {/* <h1 className="text-center text-7xl pb-3">🎨</h1> */}
-      <p className="py-5 text-lg">
+      <p className="pb-5 text-lg">
         <strong>Inpainting</strong> is a process where missing parts of an
         artwork are filled in to present a complete image. This{" "}
         <a className="underline" href="https://github.com/zeke/inpainter">


### PR DESCRIPTION
A tiny change to make sure deployments still work after the repo was moved from @zeke to @replicate.