### PR TITLE
upgrade Stable Diffusion from 1.5 to 2.1

### DIFF
--- a/pages/api/predictions/index.js
+++ b/pages/api/predictions/index.js
@@ -15,7 +15,7 @@ export default async function handler(req, res) {
   const body = JSON.stringify({
     // Pinned to a specific version of Stable Diffusion, fetched from:
     // https://replicate.com/stability-ai/stable-diffusion
-    version: "be04660a5b93ef2aff61e3668dedb4cbeb14941e62a3fd5998364a32d613e35e",
+    version: "f178fa7a1ae43a9a9af01b833b9d2ecf97b1bcb0acfd2dc5dd04895e042863f1",
     input: req.body,
   });
 


### PR DESCRIPTION
This PR tentatively updates the Inpainter app to use the 2.1 version of Stable Diffusion on Replicate.

See https://replicate.com/stability-ai/stable-diffusion/versions for info about the different versions.

In my very unscientific attempts to compare the two models, it seems like 2.x is "not as good". Maybe it has something against "a gentleman otter in a 19th century portrait".

cc @anotherjesse 

## 1.5 (very much a good otter)

![image](https://user-images.githubusercontent.com/2289/210458074-03909c53-9263-4065-8d28-caf3313404f6.png)

## 2.1 (ummm... no)

![image](https://user-images.githubusercontent.com/2289/210458110-767fa6b2-5a51-4ff9-b364-1650d6b00220.png)


