### PR TITLE
allow images from pbxt.replicate.delivery

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,8 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ["replicate.com", "replicate.delivery"],
+    domains: ["replicate.com", "replicate.delivery", "pbxt.replicate.delivery"],
   },
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
Replicate started serving prediction output URLs from a new subdomain. This PR updates the Next.js config to allow loading images from that host.

Thanks @manovotny and @nutlope for the report and the tip.

![image](https://github.com/replicate/inpainter/assets/2289/2f443bad-93f6-41fe-817f-e247a1351e46)

cc @replicate/hackers 