### PR TITLE
use remotePatterns instead of domains in Next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,20 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ["replicate.com", "replicate.delivery", "pbxt.replicate.delivery"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "replicate.com",
+      },
+      {
+        protocol: "https",
+        hostname: "replicate.delivery",
+      },
+      {
+        protocol: "https",
+        hostname: "*.replicate.delivery",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
From the Next.js docs:

> Warning: We recommend configuring strict [remotePatterns](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns) instead of domains in order to protect your application from malicious users. Only use domains if you own all the content served from the domain.