### PR TITLE
chore: disable image optimization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,23 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  swcMinify: true,
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "replicate.com",
-      },
-      {
-        protocol: "https",
-        hostname: "replicate.delivery",
-      },
-      {
-        protocol: "https",
-        hostname: "*.replicate.delivery",
-      },
-    ],
-  },
+	reactStrictMode: true,
+	swcMinify: true,
+	images: {
+		unoptimized: true,
+	},
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Disable Vercel's image optimization, as it costs a lot and doesn't provide a huge amount of value in this scenario.