### PR TITLE
fix(api): only allow predictions against ideogram

### DIFF
--- a/pages/api/predictions/index.js
+++ b/pages/api/predictions/index.js
@@ -1,41 +1,58 @@
 const addBackgroundToPNG = require("lib/add-background-to-png");
 
+const supportedModels = [
+	"ideogram-ai/ideogram-v2",
+	"ideogram-ai/ideogram-v2-turbo",
+];
+
 export default async function handler(req, res) {
-  // remove null and undefined values
-  req.body = Object.entries(req.body).reduce(
-    (a, [k, v]) => (v == null ? a : ((a[k] = v), a)),
-    {}
-  );
+	// remove null and undefined values
+	req.body = Object.entries(req.body).reduce(
+		(a, [k, v]) => (v == null ? a : ((a[k] = v), a)),
+		{},
+	);
 
-  if (req.body.mask) {
-    req.body.mask = addBackgroundToPNG(req.body.mask);
-  }
+	if (req.body.mask) {
+		req.body.mask = addBackgroundToPNG(req.body.mask);
+	}
 
-  const modelVersion = req.body.model || "ideogram-ai/ideogram-v2";
+	const modelVersion = req.body.model || "ideogram-ai/ideogram-v2";
 
-  req.body.aspect_ratio = "4:3";
+	if (!supportedModels.includes(modelVersion)) {
+		res.statusCode = 400;
+		res.end(
+			JSON.stringify({
+				detail: `Model version ${modelVersion} is not supported.`,
+			}),
+		);
+	}
 
-  const body = JSON.stringify({
-    input: req.body,
-  });
+	req.body.aspect_ratio = "4:3";
 
-  const response = await fetch(`https://api.replicate.com/v1/models/${modelVersion}/predictions`, {
-    method: "POST",
-    headers: {
-      Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,
-      "Content-Type": "application/json",
-    },
-    body,
-  });
+	const body = JSON.stringify({
+		input: req.body,
+	});
 
-  if (response.status !== 201) {
-    let error = await response.json();
-    res.statusCode = 500;
-    res.end(JSON.stringify({ detail: error.detail }));
-    return;
-  }
+	const response = await fetch(
+		`https://api.replicate.com/v1/models/${modelVersion}/predictions`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			body,
+		},
+	);
 
-  const prediction = await response.json();
-  res.statusCode = 201;
-  res.end(JSON.stringify(prediction));
+	if (response.status !== 201) {
+		const error = await response.json();
+		res.statusCode = 500;
+		res.end(JSON.stringify({ detail: error.detail }));
+		return;
+	}
+
+	const prediction = await response.json();
+	res.statusCode = 201;
+	res.end(JSON.stringify(prediction));
 }


### PR DESCRIPTION
This pull request introduces changes to the `pages/api/predictions/index.js` file to enhance input validation and improve code readability. The most important updates include adding support for a list of valid model versions and validating incoming requests against this list.

### Input validation improvements:
* Added a `supportedModels` array to define the list of valid model versions (`ideogram-ai/ideogram-v2` and `ideogram-ai/ideogram-v2-turbo`).
* Implemented a check to validate the `modelVersion` against the `supportedModels` array. If the model is not supported, the API responds with a `400 Bad Request` status and a detailed error message.

### Code readability improvements:
* Adjusted indentation and formatting for better consistency and readability, including in the `fetch` call and the error handling block.