### PR TITLE
Bring Your Own Token

### DIFF
--- a/pages/api/predictions/[id].js
+++ b/pages/api/predictions/[id].js
@@ -1,12 +1,20 @@
 export default async function handler(req, res) {
+  // Check for API token in headers
+  const apiToken = req.headers['x-replicate-api-token'];
+  if (!apiToken) {
+    res.statusCode = 401;
+    res.end(JSON.stringify({ detail: "Missing Replicate API token" }));
+    return;
+  }
+
   const response = await fetch(`https://api.replicate.com/v1/predictions/${req.query.id}`, {
     headers: {
-      Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,
+      Authorization: `Token ${apiToken}`,
       "Content-Type": "application/json",
     },
   });
   if (response.status !== 200) {
-    let error = await response.json();
+    const error = await response.json();
     res.statusCode = 500;
     res.end(JSON.stringify({ detail: error.detail }));
     return;

--- a/pages/api/predictions/index.js
+++ b/pages/api/predictions/index.js
@@ -1,6 +1,14 @@
 const addBackgroundToPNG = require("lib/add-background-to-png");
 
 export default async function handler(req, res) {
+  // Check for API token in headers
+  const apiToken = req.headers['x-replicate-api-token'];
+  if (!apiToken) {
+    res.statusCode = 401;
+    res.end(JSON.stringify({ detail: "Missing Replicate API token" }));
+    return;
+  }
+
   // remove null and undefined values
   req.body = Object.entries(req.body).reduce(
     (a, [k, v]) => (v == null ? a : ((a[k] = v), a)),
@@ -22,7 +30,7 @@ export default async function handler(req, res) {
   const response = await fetch(`https://api.replicate.com/v1/models/${modelVersion}/predictions`, {
     method: "POST",
     headers: {
-      Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,
+      Authorization: `Token ${apiToken}`,
       "Content-Type": "application/json",
     },
     body,

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,29 @@
 import Head from "next/head";
 import Link from "next/link";
+import { useState, useEffect } from "react";
 
 export default function About() {
+  const [apiToken, setApiToken] = useState("");
+  const [hasToken, setHasToken] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem("replicateApiToken");
+    if (token) {
+      setApiToken(token);
+      setHasToken(true);
+    }
+  }, []);
+
+  const handleTokenSubmit = (e) => {
+    e.preventDefault();
+    const token = e.target.token.value.trim();
+    if (token) {
+      localStorage.setItem("replicateApiToken", token);
+      setApiToken(token);
+      setHasToken(true);
+    }
+  };
+
   return (
     <div className="max-w-[512px] mx-auto p-10 bg-white rounded-lg">
       <Head>
@@ -40,11 +62,41 @@ export default function About() {
         </video>
       </Link>
 
-      <Link href="/paint">
-        <a className="py-3 block text-center bg-black text-white rounded-md mt-10">
-          Start painting
-        </a>
-      </Link>
+      {!hasToken ? (
+        <form onSubmit={handleTokenSubmit} className="mt-10">
+          <div className="mb-4">
+            <label htmlFor="token" className="block text-sm font-medium text-gray-700 mb-2">
+              Replicate API Token
+            </label>
+            <input
+              type="text"
+              id="token"
+              name="token"
+              placeholder="Enter your Replicate API token"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              required
+            />
+            <p className="mt-2 text-sm text-gray-500">
+              Get your API token from{" "}
+              <a href="https://replicate.com/account/api-tokens" className="underline" target="_blank" rel="noopener noreferrer">
+                Replicate
+              </a>
+            </p>
+          </div>
+          <button
+            type="submit"
+            className="w-full py-3 bg-black text-white rounded-md"
+          >
+            Save Token
+          </button>
+        </form>
+      ) : (
+        <Link href="/paint">
+          <a href="/paint" className="py-3 block text-center bg-black text-white rounded-md mt-10">
+            Start painting
+          </a>
+        </Link>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This site has been getting a lot of traffic lately, and much of it is abuse.

This PR changes the site to require users to enter their own Replicate API token, rather than using a token in the environment that Replicate pays for.

The user's token is then stored in browser localStorage and added as request header when making requests to the Next.js backend.